### PR TITLE
Prevent the double-locked bucket configuration

### DIFF
--- a/public/templates/Apps/TableManager/buckets/number.hbs
+++ b/public/templates/Apps/TableManager/buckets/number.hbs
@@ -1,13 +1,4 @@
-<div
-	class="{{#if buckets.locked}}alert-box locked{{/if}}"
-	data-bucket-type="number"
->
-	{{#if buckets.locked}}
-		<p class="center">
-			This bucket configuration has been locked, preventing editing
-			of the settings.
-		</p>
-	{{/if}}
+<div data-bucket-type="number">
 	<div class="input-group">
 		<label for="{{meta.idp}}-min">
 			Minimum

--- a/public/templates/Apps/TableManager/buckets/string.hbs
+++ b/public/templates/Apps/TableManager/buckets/string.hbs
@@ -1,7 +1,4 @@
-<div
-	class="{{#if buckets.locked}}alert-box locked{{/if}}"
-	data-bucket-type="string"
->
+<div data-bucket-type="string">
 	<div class="input-group">
 		<label for="">
 			Valid Options


### PR DESCRIPTION
Fixes a bug where the "You cannot edit this bucket configuration" and the red alert border would appear double-layered. The alert is there for information, but it feels very intimidating in it's double-layered form